### PR TITLE
refactor: Update MutationState to be a sealed class and improve code structure

### DIFF
--- a/lib/src/async_value.dart
+++ b/lib/src/async_value.dart
@@ -87,7 +87,7 @@ abstract class AsyncValue<T> {
 /// has succeeded with a value
 /// {@endtemplate}
 @freezed
-sealed class AsyncData<T> with _$AsyncData<T> implements AsyncValue<T> {
+abstract class AsyncData<T> with _$AsyncData<T> implements AsyncValue<T> {
   /// {@macro async_data}
   const factory AsyncData(
     T value, {
@@ -128,7 +128,7 @@ sealed class AsyncData<T> with _$AsyncData<T> implements AsyncValue<T> {
 /// A state representing that asynchronous computation has failed with an error
 /// {@endtemplate}
 @freezed
-sealed class AsyncError<T> with _$AsyncError<T> implements AsyncValue<T> {
+abstract class AsyncError<T> with _$AsyncError<T> implements AsyncValue<T> {
   /// {@macro async_error}
   const factory AsyncError(
     Object error,
@@ -171,7 +171,7 @@ sealed class AsyncError<T> with _$AsyncError<T> implements AsyncValue<T> {
 /// (e.g. from a network call).
 /// {@endtemplate}
 @freezed
-sealed class AsyncLoading<T> with _$AsyncLoading<T> implements AsyncValue<T> {
+abstract class AsyncLoading<T> with _$AsyncLoading<T> implements AsyncValue<T> {
   /// {@macro async_loading}
   const factory AsyncLoading({
     T? value,

--- a/lib/src/async_value.dart
+++ b/lib/src/async_value.dart
@@ -87,7 +87,7 @@ abstract class AsyncValue<T> {
 /// has succeeded with a value
 /// {@endtemplate}
 @freezed
-class AsyncData<T> with _$AsyncData<T> implements AsyncValue<T> {
+sealed class AsyncData<T> with _$AsyncData<T> implements AsyncValue<T> {
   /// {@macro async_data}
   const factory AsyncData(
     T value, {
@@ -128,7 +128,7 @@ class AsyncData<T> with _$AsyncData<T> implements AsyncValue<T> {
 /// A state representing that asynchronous computation has failed with an error
 /// {@endtemplate}
 @freezed
-class AsyncError<T> with _$AsyncError<T> implements AsyncValue<T> {
+sealed class AsyncError<T> with _$AsyncError<T> implements AsyncValue<T> {
   /// {@macro async_error}
   const factory AsyncError(
     Object error,
@@ -171,7 +171,7 @@ class AsyncError<T> with _$AsyncError<T> implements AsyncValue<T> {
 /// (e.g. from a network call).
 /// {@endtemplate}
 @freezed
-class AsyncLoading<T> with _$AsyncLoading<T> implements AsyncValue<T> {
+sealed class AsyncLoading<T> with _$AsyncLoading<T> implements AsyncValue<T> {
   /// {@macro async_loading}
   const factory AsyncLoading({
     T? value,

--- a/lib/src/async_value.freezed.dart
+++ b/lib/src/async_value.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,140 +10,29 @@ part of 'async_value.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 /// @nodoc
 mixin _$AsyncData<T> {
-  T get value => throw _privateConstructorUsedError;
-  bool get isLoading => throw _privateConstructorUsedError;
-  Object? get error => throw _privateConstructorUsedError;
-  StackTrace? get stackTrace => throw _privateConstructorUsedError;
+  T get value;
+  bool get isLoading;
+  Object? get error;
+  StackTrace? get stackTrace;
 
-  @JsonKey(ignore: true)
+  /// Create a copy of AsyncData
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
   $AsyncDataCopyWith<T, AsyncData<T>> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $AsyncDataCopyWith<T, $Res> {
-  factory $AsyncDataCopyWith(
-          AsyncData<T> value, $Res Function(AsyncData<T>) then) =
-      _$AsyncDataCopyWithImpl<T, $Res, AsyncData<T>>;
-  @useResult
-  $Res call({T value, bool isLoading, Object? error, StackTrace? stackTrace});
-}
-
-/// @nodoc
-class _$AsyncDataCopyWithImpl<T, $Res, $Val extends AsyncData<T>>
-    implements $AsyncDataCopyWith<T, $Res> {
-  _$AsyncDataCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? value = freezed,
-    Object? isLoading = null,
-    Object? error = freezed,
-    Object? stackTrace = freezed,
-  }) {
-    return _then(_value.copyWith(
-      value: freezed == value
-          ? _value.value
-          : value // ignore: cast_nullable_to_non_nullable
-              as T,
-      isLoading: null == isLoading
-          ? _value.isLoading
-          : isLoading // ignore: cast_nullable_to_non_nullable
-              as bool,
-      error: freezed == error ? _value.error : error,
-      stackTrace: freezed == stackTrace
-          ? _value.stackTrace
-          : stackTrace // ignore: cast_nullable_to_non_nullable
-              as StackTrace?,
-    ) as $Val);
-  }
-}
-
-/// @nodoc
-abstract class _$$_AsyncDataCopyWith<T, $Res>
-    implements $AsyncDataCopyWith<T, $Res> {
-  factory _$$_AsyncDataCopyWith(
-          _$_AsyncData<T> value, $Res Function(_$_AsyncData<T>) then) =
-      __$$_AsyncDataCopyWithImpl<T, $Res>;
-  @override
-  @useResult
-  $Res call({T value, bool isLoading, Object? error, StackTrace? stackTrace});
-}
-
-/// @nodoc
-class __$$_AsyncDataCopyWithImpl<T, $Res>
-    extends _$AsyncDataCopyWithImpl<T, $Res, _$_AsyncData<T>>
-    implements _$$_AsyncDataCopyWith<T, $Res> {
-  __$$_AsyncDataCopyWithImpl(
-      _$_AsyncData<T> _value, $Res Function(_$_AsyncData<T>) _then)
-      : super(_value, _then);
-
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? value = freezed,
-    Object? isLoading = null,
-    Object? error = freezed,
-    Object? stackTrace = freezed,
-  }) {
-    return _then(_$_AsyncData<T>(
-      freezed == value
-          ? _value.value
-          : value // ignore: cast_nullable_to_non_nullable
-              as T,
-      isLoading: null == isLoading
-          ? _value.isLoading
-          : isLoading // ignore: cast_nullable_to_non_nullable
-              as bool,
-      error: freezed == error ? _value.error : error,
-      stackTrace: freezed == stackTrace
-          ? _value.stackTrace
-          : stackTrace // ignore: cast_nullable_to_non_nullable
-              as StackTrace?,
-    ));
-  }
-}
-
-/// @nodoc
-
-class _$_AsyncData<T> extends _AsyncData<T> {
-  const _$_AsyncData(this.value,
-      {this.isLoading = false, this.error, this.stackTrace})
-      : super._();
+      _$AsyncDataCopyWithImpl<T, AsyncData<T>>(
+          this as AsyncData<T>, _$identity);
 
   @override
-  final T value;
-  @override
-  @JsonKey()
-  final bool isLoading;
-  @override
-  final Object? error;
-  @override
-  final StackTrace? stackTrace;
-
-  @override
-  String toString() {
-    return 'AsyncData<$T>(value: $value, isLoading: $isLoading, error: $error, stackTrace: $stackTrace)';
-  }
-
-  @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_AsyncData<T> &&
+            other is AsyncData<T> &&
             const DeepCollectionEquality().equals(other.value, value) &&
             (identical(other.isLoading, isLoading) ||
                 other.isLoading == isLoading) &&
@@ -159,187 +49,176 @@ class _$_AsyncData<T> extends _AsyncData<T> {
       const DeepCollectionEquality().hash(error),
       stackTrace);
 
-  @JsonKey(ignore: true)
   @override
-  @pragma('vm:prefer-inline')
-  _$$_AsyncDataCopyWith<T, _$_AsyncData<T>> get copyWith =>
-      __$$_AsyncDataCopyWithImpl<T, _$_AsyncData<T>>(this, _$identity);
-}
-
-abstract class _AsyncData<T> extends AsyncData<T> {
-  const factory _AsyncData(final T value,
-      {final bool isLoading,
-      final Object? error,
-      final StackTrace? stackTrace}) = _$_AsyncData<T>;
-  const _AsyncData._() : super._();
-
-  @override
-  T get value;
-  @override
-  bool get isLoading;
-  @override
-  Object? get error;
-  @override
-  StackTrace? get stackTrace;
-  @override
-  @JsonKey(ignore: true)
-  _$$_AsyncDataCopyWith<T, _$_AsyncData<T>> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-mixin _$AsyncError<T> {
-  Object get error => throw _privateConstructorUsedError;
-  StackTrace get stackTrace => throw _privateConstructorUsedError;
-  T? get value => throw _privateConstructorUsedError;
-  bool get hasValue => throw _privateConstructorUsedError;
-  bool get isLoading => throw _privateConstructorUsedError;
-
-  @JsonKey(ignore: true)
-  $AsyncErrorCopyWith<T, AsyncError<T>> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $AsyncErrorCopyWith<T, $Res> {
-  factory $AsyncErrorCopyWith(
-          AsyncError<T> value, $Res Function(AsyncError<T>) then) =
-      _$AsyncErrorCopyWithImpl<T, $Res, AsyncError<T>>;
-  @useResult
-  $Res call(
-      {Object error,
-      StackTrace stackTrace,
-      T? value,
-      bool hasValue,
-      bool isLoading});
-}
-
-/// @nodoc
-class _$AsyncErrorCopyWithImpl<T, $Res, $Val extends AsyncError<T>>
-    implements $AsyncErrorCopyWith<T, $Res> {
-  _$AsyncErrorCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? error = null,
-    Object? stackTrace = null,
-    Object? value = freezed,
-    Object? hasValue = null,
-    Object? isLoading = null,
-  }) {
-    return _then(_value.copyWith(
-      error: null == error ? _value.error : error,
-      stackTrace: null == stackTrace
-          ? _value.stackTrace
-          : stackTrace // ignore: cast_nullable_to_non_nullable
-              as StackTrace,
-      value: freezed == value
-          ? _value.value
-          : value // ignore: cast_nullable_to_non_nullable
-              as T?,
-      hasValue: null == hasValue
-          ? _value.hasValue
-          : hasValue // ignore: cast_nullable_to_non_nullable
-              as bool,
-      isLoading: null == isLoading
-          ? _value.isLoading
-          : isLoading // ignore: cast_nullable_to_non_nullable
-              as bool,
-    ) as $Val);
+  String toString() {
+    return 'AsyncData<$T>(value: $value, isLoading: $isLoading, error: $error, stackTrace: $stackTrace)';
   }
 }
 
 /// @nodoc
-abstract class _$$_AsyncErrorCopyWith<T, $Res>
-    implements $AsyncErrorCopyWith<T, $Res> {
-  factory _$$_AsyncErrorCopyWith(
-          _$_AsyncError<T> value, $Res Function(_$_AsyncError<T>) then) =
-      __$$_AsyncErrorCopyWithImpl<T, $Res>;
-  @override
+abstract mixin class $AsyncDataCopyWith<T, $Res> {
+  factory $AsyncDataCopyWith(
+          AsyncData<T> value, $Res Function(AsyncData<T>) _then) =
+      _$AsyncDataCopyWithImpl;
   @useResult
-  $Res call(
-      {Object error,
-      StackTrace stackTrace,
-      T? value,
-      bool hasValue,
-      bool isLoading});
+  $Res call({T value, bool isLoading, Object? error, StackTrace? stackTrace});
 }
 
 /// @nodoc
-class __$$_AsyncErrorCopyWithImpl<T, $Res>
-    extends _$AsyncErrorCopyWithImpl<T, $Res, _$_AsyncError<T>>
-    implements _$$_AsyncErrorCopyWith<T, $Res> {
-  __$$_AsyncErrorCopyWithImpl(
-      _$_AsyncError<T> _value, $Res Function(_$_AsyncError<T>) _then)
-      : super(_value, _then);
+class _$AsyncDataCopyWithImpl<T, $Res> implements $AsyncDataCopyWith<T, $Res> {
+  _$AsyncDataCopyWithImpl(this._self, this._then);
 
+  final AsyncData<T> _self;
+  final $Res Function(AsyncData<T>) _then;
+
+  /// Create a copy of AsyncData
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? error = null,
-    Object? stackTrace = null,
     Object? value = freezed,
-    Object? hasValue = null,
     Object? isLoading = null,
+    Object? error = freezed,
+    Object? stackTrace = freezed,
   }) {
-    return _then(_$_AsyncError<T>(
-      null == error ? _value.error : error,
-      null == stackTrace
-          ? _value.stackTrace
-          : stackTrace // ignore: cast_nullable_to_non_nullable
-              as StackTrace,
+    return _then(_self.copyWith(
       value: freezed == value
-          ? _value.value
+          ? _self.value
           : value // ignore: cast_nullable_to_non_nullable
-              as T?,
-      hasValue: null == hasValue
-          ? _value.hasValue
-          : hasValue // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as T,
       isLoading: null == isLoading
-          ? _value.isLoading
+          ? _self.isLoading
           : isLoading // ignore: cast_nullable_to_non_nullable
               as bool,
+      error: freezed == error ? _self.error : error,
+      stackTrace: freezed == stackTrace
+          ? _self.stackTrace
+          : stackTrace // ignore: cast_nullable_to_non_nullable
+              as StackTrace?,
     ));
   }
 }
 
 /// @nodoc
 
-class _$_AsyncError<T> extends _AsyncError<T> {
-  const _$_AsyncError(this.error, this.stackTrace,
-      {this.value, this.hasValue = false, this.isLoading = false})
+class _AsyncData<T> extends AsyncData<T> {
+  const _AsyncData(this.value,
+      {this.isLoading = false, this.error, this.stackTrace})
       : super._();
 
   @override
-  final Object error;
-  @override
-  final StackTrace stackTrace;
-  @override
-  final T? value;
-  @override
-  @JsonKey()
-  final bool hasValue;
+  final T value;
   @override
   @JsonKey()
   final bool isLoading;
+  @override
+  final Object? error;
+  @override
+  final StackTrace? stackTrace;
+
+  /// Create a copy of AsyncData
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$AsyncDataCopyWith<T, _AsyncData<T>> get copyWith =>
+      __$AsyncDataCopyWithImpl<T, _AsyncData<T>>(this, _$identity);
 
   @override
-  String toString() {
-    return 'AsyncError<$T>(error: $error, stackTrace: $stackTrace, value: $value, hasValue: $hasValue, isLoading: $isLoading)';
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _AsyncData<T> &&
+            const DeepCollectionEquality().equals(other.value, value) &&
+            (identical(other.isLoading, isLoading) ||
+                other.isLoading == isLoading) &&
+            const DeepCollectionEquality().equals(other.error, error) &&
+            (identical(other.stackTrace, stackTrace) ||
+                other.stackTrace == stackTrace));
   }
 
   @override
-  bool operator ==(dynamic other) {
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(value),
+      isLoading,
+      const DeepCollectionEquality().hash(error),
+      stackTrace);
+
+  @override
+  String toString() {
+    return 'AsyncData<$T>(value: $value, isLoading: $isLoading, error: $error, stackTrace: $stackTrace)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$AsyncDataCopyWith<T, $Res>
+    implements $AsyncDataCopyWith<T, $Res> {
+  factory _$AsyncDataCopyWith(
+          _AsyncData<T> value, $Res Function(_AsyncData<T>) _then) =
+      __$AsyncDataCopyWithImpl;
+  @override
+  @useResult
+  $Res call({T value, bool isLoading, Object? error, StackTrace? stackTrace});
+}
+
+/// @nodoc
+class __$AsyncDataCopyWithImpl<T, $Res>
+    implements _$AsyncDataCopyWith<T, $Res> {
+  __$AsyncDataCopyWithImpl(this._self, this._then);
+
+  final _AsyncData<T> _self;
+  final $Res Function(_AsyncData<T>) _then;
+
+  /// Create a copy of AsyncData
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? value = freezed,
+    Object? isLoading = null,
+    Object? error = freezed,
+    Object? stackTrace = freezed,
+  }) {
+    return _then(_AsyncData<T>(
+      freezed == value
+          ? _self.value
+          : value // ignore: cast_nullable_to_non_nullable
+              as T,
+      isLoading: null == isLoading
+          ? _self.isLoading
+          : isLoading // ignore: cast_nullable_to_non_nullable
+              as bool,
+      error: freezed == error ? _self.error : error,
+      stackTrace: freezed == stackTrace
+          ? _self.stackTrace
+          : stackTrace // ignore: cast_nullable_to_non_nullable
+              as StackTrace?,
+    ));
+  }
+}
+
+/// @nodoc
+mixin _$AsyncError<T> {
+  Object get error;
+  StackTrace get stackTrace;
+  T? get value;
+  bool get hasValue;
+  bool get isLoading;
+
+  /// Create a copy of AsyncError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $AsyncErrorCopyWith<T, AsyncError<T>> get copyWith =>
+      _$AsyncErrorCopyWithImpl<T, AsyncError<T>>(
+          this as AsyncError<T>, _$identity);
+
+  @override
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_AsyncError<T> &&
+            other is AsyncError<T> &&
             const DeepCollectionEquality().equals(other.error, error) &&
             (identical(other.stackTrace, stackTrace) ||
                 other.stackTrace == stackTrace) &&
@@ -359,117 +238,62 @@ class _$_AsyncError<T> extends _AsyncError<T> {
       hasValue,
       isLoading);
 
-  @JsonKey(ignore: true)
   @override
-  @pragma('vm:prefer-inline')
-  _$$_AsyncErrorCopyWith<T, _$_AsyncError<T>> get copyWith =>
-      __$$_AsyncErrorCopyWithImpl<T, _$_AsyncError<T>>(this, _$identity);
-}
-
-abstract class _AsyncError<T> extends AsyncError<T> {
-  const factory _AsyncError(final Object error, final StackTrace stackTrace,
-      {final T? value,
-      final bool hasValue,
-      final bool isLoading}) = _$_AsyncError<T>;
-  const _AsyncError._() : super._();
-
-  @override
-  Object get error;
-  @override
-  StackTrace get stackTrace;
-  @override
-  T? get value;
-  @override
-  bool get hasValue;
-  @override
-  bool get isLoading;
-  @override
-  @JsonKey(ignore: true)
-  _$$_AsyncErrorCopyWith<T, _$_AsyncError<T>> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-mixin _$AsyncLoading<T> {
-  T? get value => throw _privateConstructorUsedError;
-  bool get hasValue => throw _privateConstructorUsedError;
-
-  @JsonKey(ignore: true)
-  $AsyncLoadingCopyWith<T, AsyncLoading<T>> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $AsyncLoadingCopyWith<T, $Res> {
-  factory $AsyncLoadingCopyWith(
-          AsyncLoading<T> value, $Res Function(AsyncLoading<T>) then) =
-      _$AsyncLoadingCopyWithImpl<T, $Res, AsyncLoading<T>>;
-  @useResult
-  $Res call({T? value, bool hasValue});
-}
-
-/// @nodoc
-class _$AsyncLoadingCopyWithImpl<T, $Res, $Val extends AsyncLoading<T>>
-    implements $AsyncLoadingCopyWith<T, $Res> {
-  _$AsyncLoadingCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? value = freezed,
-    Object? hasValue = null,
-  }) {
-    return _then(_value.copyWith(
-      value: freezed == value
-          ? _value.value
-          : value // ignore: cast_nullable_to_non_nullable
-              as T?,
-      hasValue: null == hasValue
-          ? _value.hasValue
-          : hasValue // ignore: cast_nullable_to_non_nullable
-              as bool,
-    ) as $Val);
+  String toString() {
+    return 'AsyncError<$T>(error: $error, stackTrace: $stackTrace, value: $value, hasValue: $hasValue, isLoading: $isLoading)';
   }
 }
 
 /// @nodoc
-abstract class _$$_AsyncLoadingCopyWith<T, $Res>
-    implements $AsyncLoadingCopyWith<T, $Res> {
-  factory _$$_AsyncLoadingCopyWith(
-          _$_AsyncLoading<T> value, $Res Function(_$_AsyncLoading<T>) then) =
-      __$$_AsyncLoadingCopyWithImpl<T, $Res>;
-  @override
+abstract mixin class $AsyncErrorCopyWith<T, $Res> {
+  factory $AsyncErrorCopyWith(
+          AsyncError<T> value, $Res Function(AsyncError<T>) _then) =
+      _$AsyncErrorCopyWithImpl;
   @useResult
-  $Res call({T? value, bool hasValue});
+  $Res call(
+      {Object error,
+      StackTrace stackTrace,
+      T? value,
+      bool hasValue,
+      bool isLoading});
 }
 
 /// @nodoc
-class __$$_AsyncLoadingCopyWithImpl<T, $Res>
-    extends _$AsyncLoadingCopyWithImpl<T, $Res, _$_AsyncLoading<T>>
-    implements _$$_AsyncLoadingCopyWith<T, $Res> {
-  __$$_AsyncLoadingCopyWithImpl(
-      _$_AsyncLoading<T> _value, $Res Function(_$_AsyncLoading<T>) _then)
-      : super(_value, _then);
+class _$AsyncErrorCopyWithImpl<T, $Res>
+    implements $AsyncErrorCopyWith<T, $Res> {
+  _$AsyncErrorCopyWithImpl(this._self, this._then);
 
+  final AsyncError<T> _self;
+  final $Res Function(AsyncError<T>) _then;
+
+  /// Create a copy of AsyncError
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
+    Object? error = null,
+    Object? stackTrace = null,
     Object? value = freezed,
     Object? hasValue = null,
+    Object? isLoading = null,
   }) {
-    return _then(_$_AsyncLoading<T>(
+    return _then(_self.copyWith(
+      error: null == error ? _self.error : error,
+      stackTrace: null == stackTrace
+          ? _self.stackTrace
+          : stackTrace // ignore: cast_nullable_to_non_nullable
+              as StackTrace,
       value: freezed == value
-          ? _value.value
+          ? _self.value
           : value // ignore: cast_nullable_to_non_nullable
               as T?,
       hasValue: null == hasValue
-          ? _value.hasValue
+          ? _self.hasValue
           : hasValue // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isLoading: null == isLoading
+          ? _self.isLoading
+          : isLoading // ignore: cast_nullable_to_non_nullable
               as bool,
     ));
   }
@@ -477,25 +301,137 @@ class __$$_AsyncLoadingCopyWithImpl<T, $Res>
 
 /// @nodoc
 
-class _$_AsyncLoading<T> extends _AsyncLoading<T> {
-  const _$_AsyncLoading({this.value, this.hasValue = false}) : super._();
+class _AsyncError<T> extends AsyncError<T> {
+  const _AsyncError(this.error, this.stackTrace,
+      {this.value, this.hasValue = false, this.isLoading = false})
+      : super._();
 
+  @override
+  final Object error;
+  @override
+  final StackTrace stackTrace;
   @override
   final T? value;
   @override
   @JsonKey()
   final bool hasValue;
+  @override
+  @JsonKey()
+  final bool isLoading;
+
+  /// Create a copy of AsyncError
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$AsyncErrorCopyWith<T, _AsyncError<T>> get copyWith =>
+      __$AsyncErrorCopyWithImpl<T, _AsyncError<T>>(this, _$identity);
 
   @override
-  String toString() {
-    return 'AsyncLoading<$T>(value: $value, hasValue: $hasValue)';
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _AsyncError<T> &&
+            const DeepCollectionEquality().equals(other.error, error) &&
+            (identical(other.stackTrace, stackTrace) ||
+                other.stackTrace == stackTrace) &&
+            const DeepCollectionEquality().equals(other.value, value) &&
+            (identical(other.hasValue, hasValue) ||
+                other.hasValue == hasValue) &&
+            (identical(other.isLoading, isLoading) ||
+                other.isLoading == isLoading));
   }
 
   @override
-  bool operator ==(dynamic other) {
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(error),
+      stackTrace,
+      const DeepCollectionEquality().hash(value),
+      hasValue,
+      isLoading);
+
+  @override
+  String toString() {
+    return 'AsyncError<$T>(error: $error, stackTrace: $stackTrace, value: $value, hasValue: $hasValue, isLoading: $isLoading)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$AsyncErrorCopyWith<T, $Res>
+    implements $AsyncErrorCopyWith<T, $Res> {
+  factory _$AsyncErrorCopyWith(
+          _AsyncError<T> value, $Res Function(_AsyncError<T>) _then) =
+      __$AsyncErrorCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {Object error,
+      StackTrace stackTrace,
+      T? value,
+      bool hasValue,
+      bool isLoading});
+}
+
+/// @nodoc
+class __$AsyncErrorCopyWithImpl<T, $Res>
+    implements _$AsyncErrorCopyWith<T, $Res> {
+  __$AsyncErrorCopyWithImpl(this._self, this._then);
+
+  final _AsyncError<T> _self;
+  final $Res Function(_AsyncError<T>) _then;
+
+  /// Create a copy of AsyncError
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? error = null,
+    Object? stackTrace = null,
+    Object? value = freezed,
+    Object? hasValue = null,
+    Object? isLoading = null,
+  }) {
+    return _then(_AsyncError<T>(
+      null == error ? _self.error : error,
+      null == stackTrace
+          ? _self.stackTrace
+          : stackTrace // ignore: cast_nullable_to_non_nullable
+              as StackTrace,
+      value: freezed == value
+          ? _self.value
+          : value // ignore: cast_nullable_to_non_nullable
+              as T?,
+      hasValue: null == hasValue
+          ? _self.hasValue
+          : hasValue // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isLoading: null == isLoading
+          ? _self.isLoading
+          : isLoading // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
+}
+
+/// @nodoc
+mixin _$AsyncLoading<T> {
+  T? get value;
+  bool get hasValue;
+
+  /// Create a copy of AsyncLoading
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $AsyncLoadingCopyWith<T, AsyncLoading<T>> get copyWith =>
+      _$AsyncLoadingCopyWithImpl<T, AsyncLoading<T>>(
+          this as AsyncLoading<T>, _$identity);
+
+  @override
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_AsyncLoading<T> &&
+            other is AsyncLoading<T> &&
             const DeepCollectionEquality().equals(other.value, value) &&
             (identical(other.hasValue, hasValue) ||
                 other.hasValue == hasValue));
@@ -505,24 +441,127 @@ class _$_AsyncLoading<T> extends _AsyncLoading<T> {
   int get hashCode => Object.hash(
       runtimeType, const DeepCollectionEquality().hash(value), hasValue);
 
-  @JsonKey(ignore: true)
+  @override
+  String toString() {
+    return 'AsyncLoading<$T>(value: $value, hasValue: $hasValue)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $AsyncLoadingCopyWith<T, $Res> {
+  factory $AsyncLoadingCopyWith(
+          AsyncLoading<T> value, $Res Function(AsyncLoading<T>) _then) =
+      _$AsyncLoadingCopyWithImpl;
+  @useResult
+  $Res call({T? value, bool hasValue});
+}
+
+/// @nodoc
+class _$AsyncLoadingCopyWithImpl<T, $Res>
+    implements $AsyncLoadingCopyWith<T, $Res> {
+  _$AsyncLoadingCopyWithImpl(this._self, this._then);
+
+  final AsyncLoading<T> _self;
+  final $Res Function(AsyncLoading<T>) _then;
+
+  /// Create a copy of AsyncLoading
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? value = freezed,
+    Object? hasValue = null,
+  }) {
+    return _then(_self.copyWith(
+      value: freezed == value
+          ? _self.value
+          : value // ignore: cast_nullable_to_non_nullable
+              as T?,
+      hasValue: null == hasValue
+          ? _self.hasValue
+          : hasValue // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _AsyncLoading<T> extends AsyncLoading<T> {
+  const _AsyncLoading({this.value, this.hasValue = false}) : super._();
+
+  @override
+  final T? value;
+  @override
+  @JsonKey()
+  final bool hasValue;
+
+  /// Create a copy of AsyncLoading
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$AsyncLoadingCopyWith<T, _AsyncLoading<T>> get copyWith =>
+      __$AsyncLoadingCopyWithImpl<T, _AsyncLoading<T>>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _AsyncLoading<T> &&
+            const DeepCollectionEquality().equals(other.value, value) &&
+            (identical(other.hasValue, hasValue) ||
+                other.hasValue == hasValue));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, const DeepCollectionEquality().hash(value), hasValue);
+
+  @override
+  String toString() {
+    return 'AsyncLoading<$T>(value: $value, hasValue: $hasValue)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$AsyncLoadingCopyWith<T, $Res>
+    implements $AsyncLoadingCopyWith<T, $Res> {
+  factory _$AsyncLoadingCopyWith(
+          _AsyncLoading<T> value, $Res Function(_AsyncLoading<T>) _then) =
+      __$AsyncLoadingCopyWithImpl;
+  @override
+  @useResult
+  $Res call({T? value, bool hasValue});
+}
+
+/// @nodoc
+class __$AsyncLoadingCopyWithImpl<T, $Res>
+    implements _$AsyncLoadingCopyWith<T, $Res> {
+  __$AsyncLoadingCopyWithImpl(this._self, this._then);
+
+  final _AsyncLoading<T> _self;
+  final $Res Function(_AsyncLoading<T>) _then;
+
+  /// Create a copy of AsyncLoading
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
-  _$$_AsyncLoadingCopyWith<T, _$_AsyncLoading<T>> get copyWith =>
-      __$$_AsyncLoadingCopyWithImpl<T, _$_AsyncLoading<T>>(this, _$identity);
+  $Res call({
+    Object? value = freezed,
+    Object? hasValue = null,
+  }) {
+    return _then(_AsyncLoading<T>(
+      value: freezed == value
+          ? _self.value
+          : value // ignore: cast_nullable_to_non_nullable
+              as T?,
+      hasValue: null == hasValue
+          ? _self.hasValue
+          : hasValue // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
 }
 
-abstract class _AsyncLoading<T> extends AsyncLoading<T> {
-  const factory _AsyncLoading({final T? value, final bool hasValue}) =
-      _$_AsyncLoading<T>;
-  const _AsyncLoading._() : super._();
-
-  @override
-  T? get value;
-  @override
-  bool get hasValue;
-  @override
-  @JsonKey(ignore: true)
-  _$$_AsyncLoadingCopyWith<T, _$_AsyncLoading<T>> get copyWith =>
-      throw _privateConstructorUsedError;
-}
+// dart format on

--- a/lib/src/mutation_cubit.dart
+++ b/lib/src/mutation_cubit.dart
@@ -90,7 +90,7 @@ abstract class MutationCubit<I, O> extends Cubit<MutationState<O>> {
 
 /// The state of the [MutationCubit].
 @freezed
-class MutationState<T> with _$MutationState<T> {
+sealed class MutationState<T> with _$MutationState<T> {
   /// The cubit is in the `idle` state, which means
   /// that mutation has not been invoked yet.
   const factory MutationState.idle() = _Idle<T>;

--- a/lib/src/mutation_cubit.dart
+++ b/lib/src/mutation_cubit.dart
@@ -35,9 +35,9 @@ abstract class MutationCubit<I, O> extends Cubit<MutationState<O>> {
   void onChange(Change<MutationState<O>> change) {
     super.onChange(change);
     final nextState = change.nextState;
-    if (nextState is _Success<O>) {
+    if (nextState is Success<O>) {
       onSuccess(nextState.result);
-    } else if (nextState is _Failure<O>) {
+    } else if (nextState is Failure<O>) {
       AsyncCubitsLogger.error(
         debugKey,
         'Mutation failed',
@@ -65,7 +65,7 @@ abstract class MutationCubit<I, O> extends Cubit<MutationState<O>> {
     }
 
     final state = this.state;
-    if (state is _Failure && !canRetry) {
+    if (state is Failure && !canRetry) {
       AsyncCubitsLogger.info(
         debugKey,
         'Mutation failed and cannot be retried. Ignoring invoke.',
@@ -93,35 +93,39 @@ abstract class MutationCubit<I, O> extends Cubit<MutationState<O>> {
 sealed class MutationState<T> with _$MutationState<T> {
   /// The cubit is in the `idle` state, which means
   /// that mutation has not been invoked yet.
-  const factory MutationState.idle() = _Idle<T>;
+  const factory MutationState.idle() = Idle<T>;
 
   /// {@template mutation_state_loading}
   /// The cubit is in the `loading` state, which means
   /// that the mutation is invoked and is currently in progress.
   /// {@endtemplate}
-  const factory MutationState.loading() = _Loading<T>;
+  const factory MutationState.loading() = Loading<T>;
 
   /// {@template mutation_state_success}
   /// The cubit is in the `success` state, which means
   /// that the mutation was successful.
   /// {@endtemplate}
-  const factory MutationState.success(T result) = _Success<T>;
+  const factory MutationState.success(
+    T result,
+  ) = Success<T>;
 
   /// {@template mutation_state_failure}
   /// The cubit is in the `failure` state, which means
   /// that the mutation failed.
   /// {@endtemplate}
-  const factory MutationState.failure(Object error, StackTrace stackTrace) =
-      _Failure<T>;
+  const factory MutationState.failure(
+    Object error,
+    StackTrace stackTrace,
+  ) = Failure<T>;
 
   const MutationState._();
 
   /// {@macro mutation_state_loading}
-  bool get isLoading => this is _Loading<T>;
+  bool get isLoading => this is Loading<T>;
 
   /// {@macro mutation_state_success}
-  bool get isSuccess => this is _Success<T>;
+  bool get isSuccess => this is Success<T>;
 
   /// {@macro mutation_state_failure}
-  bool get isFailure => this is _Failure<T>;
+  bool get isFailure => this is Failure<T>;
 }

--- a/lib/src/mutation_cubit.freezed.dart
+++ b/lib/src/mutation_cubit.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,348 +10,152 @@ part of 'mutation_cubit.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
 
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
-
 /// @nodoc
-mixin _$MutationState<T> {
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>({
-    required TResult Function() idle,
-    required TResult Function() loading,
-    required TResult Function(T result) success,
-    required TResult Function(Object error, StackTrace stackTrace) failure,
-  }) =>
-      throw _privateConstructorUsedError;
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function()? idle,
-    TResult? Function()? loading,
-    TResult? Function(T result)? success,
-    TResult? Function(Object error, StackTrace stackTrace)? failure,
-  }) =>
-      throw _privateConstructorUsedError;
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>({
-    TResult Function()? idle,
-    TResult Function()? loading,
-    TResult Function(T result)? success,
-    TResult Function(Object error, StackTrace stackTrace)? failure,
-    required TResult orElse(),
-  }) =>
-      throw _privateConstructorUsedError;
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>({
-    required TResult Function(_Idle<T> value) idle,
-    required TResult Function(_Loading<T> value) loading,
-    required TResult Function(_Success<T> value) success,
-    required TResult Function(_Failure<T> value) failure,
-  }) =>
-      throw _privateConstructorUsedError;
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(_Idle<T> value)? idle,
-    TResult? Function(_Loading<T> value)? loading,
-    TResult? Function(_Success<T> value)? success,
-    TResult? Function(_Failure<T> value)? failure,
-  }) =>
-      throw _privateConstructorUsedError;
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>({
-    TResult Function(_Idle<T> value)? idle,
-    TResult Function(_Loading<T> value)? loading,
-    TResult Function(_Success<T> value)? success,
-    TResult Function(_Failure<T> value)? failure,
-    required TResult orElse(),
-  }) =>
-      throw _privateConstructorUsedError;
+mixin _$MutationState<T> implements DiagnosticableTreeMixin {
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    properties..add(DiagnosticsProperty('type', 'MutationState<$T>'));
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is MutationState<T>);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
+    return 'MutationState<$T>()';
+  }
 }
 
 /// @nodoc
-abstract class $MutationStateCopyWith<T, $Res> {
-  factory $MutationStateCopyWith(
-          MutationState<T> value, $Res Function(MutationState<T>) then) =
-      _$MutationStateCopyWithImpl<T, $Res, MutationState<T>>;
-}
-
-/// @nodoc
-class _$MutationStateCopyWithImpl<T, $Res, $Val extends MutationState<T>>
-    implements $MutationStateCopyWith<T, $Res> {
-  _$MutationStateCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-}
-
-/// @nodoc
-abstract class _$$_IdleCopyWith<T, $Res> {
-  factory _$$_IdleCopyWith(_$_Idle<T> value, $Res Function(_$_Idle<T>) then) =
-      __$$_IdleCopyWithImpl<T, $Res>;
-}
-
-/// @nodoc
-class __$$_IdleCopyWithImpl<T, $Res>
-    extends _$MutationStateCopyWithImpl<T, $Res, _$_Idle<T>>
-    implements _$$_IdleCopyWith<T, $Res> {
-  __$$_IdleCopyWithImpl(_$_Idle<T> _value, $Res Function(_$_Idle<T>) _then)
-      : super(_value, _then);
+class $MutationStateCopyWith<T, $Res> {
+  $MutationStateCopyWith(
+      MutationState<T> _, $Res Function(MutationState<T>) __);
 }
 
 /// @nodoc
 
-class _$_Idle<T> extends _Idle<T> with DiagnosticableTreeMixin {
-  const _$_Idle() : super._();
+class _Idle<T> extends MutationState<T> with DiagnosticableTreeMixin {
+  const _Idle() : super._();
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    properties..add(DiagnosticsProperty('type', 'MutationState<$T>.idle'));
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _Idle<T>);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
 
   @override
   String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
     return 'MutationState<$T>.idle()';
   }
+}
+
+/// @nodoc
+
+class _Loading<T> extends MutationState<T> with DiagnosticableTreeMixin {
+  const _Loading() : super._();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    properties.add(DiagnosticsProperty('type', 'MutationState<$T>.idle'));
+    properties..add(DiagnosticsProperty('type', 'MutationState<$T>.loading'));
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
-        (other.runtimeType == runtimeType && other is _$_Idle<T>);
+        (other.runtimeType == runtimeType && other is _Loading<T>);
   }
 
   @override
   int get hashCode => runtimeType.hashCode;
-
-  @override
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>({
-    required TResult Function() idle,
-    required TResult Function() loading,
-    required TResult Function(T result) success,
-    required TResult Function(Object error, StackTrace stackTrace) failure,
-  }) {
-    return idle();
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function()? idle,
-    TResult? Function()? loading,
-    TResult? Function(T result)? success,
-    TResult? Function(Object error, StackTrace stackTrace)? failure,
-  }) {
-    return idle?.call();
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>({
-    TResult Function()? idle,
-    TResult Function()? loading,
-    TResult Function(T result)? success,
-    TResult Function(Object error, StackTrace stackTrace)? failure,
-    required TResult orElse(),
-  }) {
-    if (idle != null) {
-      return idle();
-    }
-    return orElse();
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>({
-    required TResult Function(_Idle<T> value) idle,
-    required TResult Function(_Loading<T> value) loading,
-    required TResult Function(_Success<T> value) success,
-    required TResult Function(_Failure<T> value) failure,
-  }) {
-    return idle(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(_Idle<T> value)? idle,
-    TResult? Function(_Loading<T> value)? loading,
-    TResult? Function(_Success<T> value)? success,
-    TResult? Function(_Failure<T> value)? failure,
-  }) {
-    return idle?.call(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>({
-    TResult Function(_Idle<T> value)? idle,
-    TResult Function(_Loading<T> value)? loading,
-    TResult Function(_Success<T> value)? success,
-    TResult Function(_Failure<T> value)? failure,
-    required TResult orElse(),
-  }) {
-    if (idle != null) {
-      return idle(this);
-    }
-    return orElse();
-  }
-}
-
-abstract class _Idle<T> extends MutationState<T> {
-  const factory _Idle() = _$_Idle<T>;
-  const _Idle._() : super._();
-}
-
-/// @nodoc
-abstract class _$$_LoadingCopyWith<T, $Res> {
-  factory _$$_LoadingCopyWith(
-          _$_Loading<T> value, $Res Function(_$_Loading<T>) then) =
-      __$$_LoadingCopyWithImpl<T, $Res>;
-}
-
-/// @nodoc
-class __$$_LoadingCopyWithImpl<T, $Res>
-    extends _$MutationStateCopyWithImpl<T, $Res, _$_Loading<T>>
-    implements _$$_LoadingCopyWith<T, $Res> {
-  __$$_LoadingCopyWithImpl(
-      _$_Loading<T> _value, $Res Function(_$_Loading<T>) _then)
-      : super(_value, _then);
-}
-
-/// @nodoc
-
-class _$_Loading<T> extends _Loading<T> with DiagnosticableTreeMixin {
-  const _$_Loading() : super._();
 
   @override
   String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
     return 'MutationState<$T>.loading()';
   }
-
-  @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    properties.add(DiagnosticsProperty('type', 'MutationState<$T>.loading'));
-  }
-
-  @override
-  bool operator ==(dynamic other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType && other is _$_Loading<T>);
-  }
-
-  @override
-  int get hashCode => runtimeType.hashCode;
-
-  @override
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>({
-    required TResult Function() idle,
-    required TResult Function() loading,
-    required TResult Function(T result) success,
-    required TResult Function(Object error, StackTrace stackTrace) failure,
-  }) {
-    return loading();
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function()? idle,
-    TResult? Function()? loading,
-    TResult? Function(T result)? success,
-    TResult? Function(Object error, StackTrace stackTrace)? failure,
-  }) {
-    return loading?.call();
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>({
-    TResult Function()? idle,
-    TResult Function()? loading,
-    TResult Function(T result)? success,
-    TResult Function(Object error, StackTrace stackTrace)? failure,
-    required TResult orElse(),
-  }) {
-    if (loading != null) {
-      return loading();
-    }
-    return orElse();
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>({
-    required TResult Function(_Idle<T> value) idle,
-    required TResult Function(_Loading<T> value) loading,
-    required TResult Function(_Success<T> value) success,
-    required TResult Function(_Failure<T> value) failure,
-  }) {
-    return loading(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(_Idle<T> value)? idle,
-    TResult? Function(_Loading<T> value)? loading,
-    TResult? Function(_Success<T> value)? success,
-    TResult? Function(_Failure<T> value)? failure,
-  }) {
-    return loading?.call(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>({
-    TResult Function(_Idle<T> value)? idle,
-    TResult Function(_Loading<T> value)? loading,
-    TResult Function(_Success<T> value)? success,
-    TResult Function(_Failure<T> value)? failure,
-    required TResult orElse(),
-  }) {
-    if (loading != null) {
-      return loading(this);
-    }
-    return orElse();
-  }
-}
-
-abstract class _Loading<T> extends MutationState<T> {
-  const factory _Loading() = _$_Loading<T>;
-  const _Loading._() : super._();
 }
 
 /// @nodoc
-abstract class _$$_SuccessCopyWith<T, $Res> {
-  factory _$$_SuccessCopyWith(
-          _$_Success<T> value, $Res Function(_$_Success<T>) then) =
-      __$$_SuccessCopyWithImpl<T, $Res>;
+
+class _Success<T> extends MutationState<T> with DiagnosticableTreeMixin {
+  const _Success(this.result) : super._();
+
+  final T result;
+
+  /// Create a copy of MutationState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$SuccessCopyWith<T, _Success<T>> get copyWith =>
+      __$SuccessCopyWithImpl<T, _Success<T>>(this, _$identity);
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    properties
+      ..add(DiagnosticsProperty('type', 'MutationState<$T>.success'))
+      ..add(DiagnosticsProperty('result', result));
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _Success<T> &&
+            const DeepCollectionEquality().equals(other.result, result));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(result));
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
+    return 'MutationState<$T>.success(result: $result)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$SuccessCopyWith<T, $Res>
+    implements $MutationStateCopyWith<T, $Res> {
+  factory _$SuccessCopyWith(
+          _Success<T> value, $Res Function(_Success<T>) _then) =
+      __$SuccessCopyWithImpl;
   @useResult
   $Res call({T result});
 }
 
 /// @nodoc
-class __$$_SuccessCopyWithImpl<T, $Res>
-    extends _$MutationStateCopyWithImpl<T, $Res, _$_Success<T>>
-    implements _$$_SuccessCopyWith<T, $Res> {
-  __$$_SuccessCopyWithImpl(
-      _$_Success<T> _value, $Res Function(_$_Success<T>) _then)
-      : super(_value, _then);
+class __$SuccessCopyWithImpl<T, $Res> implements _$SuccessCopyWith<T, $Res> {
+  __$SuccessCopyWithImpl(this._self, this._then);
 
+  final _Success<T> _self;
+  final $Res Function(_Success<T>) _then;
+
+  /// Create a copy of MutationState
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
-  @override
   $Res call({
     Object? result = freezed,
   }) {
-    return _then(_$_Success<T>(
+    return _then(_Success<T>(
       freezed == result
-          ? _value.result
+          ? _self.result
           : result // ignore: cast_nullable_to_non_nullable
               as T,
     ));
@@ -359,179 +164,21 @@ class __$$_SuccessCopyWithImpl<T, $Res>
 
 /// @nodoc
 
-class _$_Success<T> extends _Success<T> with DiagnosticableTreeMixin {
-  const _$_Success(this.result) : super._();
+class _Failure<T> extends MutationState<T> with DiagnosticableTreeMixin {
+  const _Failure(this.error, this.stackTrace) : super._();
 
-  @override
-  final T result;
-
-  @override
-  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
-    return 'MutationState<$T>.success(result: $result)';
-  }
-
-  @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    properties
-      ..add(DiagnosticsProperty('type', 'MutationState<$T>.success'))
-      ..add(DiagnosticsProperty('result', result));
-  }
-
-  @override
-  bool operator ==(dynamic other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$_Success<T> &&
-            const DeepCollectionEquality().equals(other.result, result));
-  }
-
-  @override
-  int get hashCode =>
-      Object.hash(runtimeType, const DeepCollectionEquality().hash(result));
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$_SuccessCopyWith<T, _$_Success<T>> get copyWith =>
-      __$$_SuccessCopyWithImpl<T, _$_Success<T>>(this, _$identity);
-
-  @override
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>({
-    required TResult Function() idle,
-    required TResult Function() loading,
-    required TResult Function(T result) success,
-    required TResult Function(Object error, StackTrace stackTrace) failure,
-  }) {
-    return success(result);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function()? idle,
-    TResult? Function()? loading,
-    TResult? Function(T result)? success,
-    TResult? Function(Object error, StackTrace stackTrace)? failure,
-  }) {
-    return success?.call(result);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>({
-    TResult Function()? idle,
-    TResult Function()? loading,
-    TResult Function(T result)? success,
-    TResult Function(Object error, StackTrace stackTrace)? failure,
-    required TResult orElse(),
-  }) {
-    if (success != null) {
-      return success(result);
-    }
-    return orElse();
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>({
-    required TResult Function(_Idle<T> value) idle,
-    required TResult Function(_Loading<T> value) loading,
-    required TResult Function(_Success<T> value) success,
-    required TResult Function(_Failure<T> value) failure,
-  }) {
-    return success(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(_Idle<T> value)? idle,
-    TResult? Function(_Loading<T> value)? loading,
-    TResult? Function(_Success<T> value)? success,
-    TResult? Function(_Failure<T> value)? failure,
-  }) {
-    return success?.call(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>({
-    TResult Function(_Idle<T> value)? idle,
-    TResult Function(_Loading<T> value)? loading,
-    TResult Function(_Success<T> value)? success,
-    TResult Function(_Failure<T> value)? failure,
-    required TResult orElse(),
-  }) {
-    if (success != null) {
-      return success(this);
-    }
-    return orElse();
-  }
-}
-
-abstract class _Success<T> extends MutationState<T> {
-  const factory _Success(final T result) = _$_Success<T>;
-  const _Success._() : super._();
-
-  T get result;
-  @JsonKey(ignore: true)
-  _$$_SuccessCopyWith<T, _$_Success<T>> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class _$$_FailureCopyWith<T, $Res> {
-  factory _$$_FailureCopyWith(
-          _$_Failure<T> value, $Res Function(_$_Failure<T>) then) =
-      __$$_FailureCopyWithImpl<T, $Res>;
-  @useResult
-  $Res call({Object error, StackTrace stackTrace});
-}
-
-/// @nodoc
-class __$$_FailureCopyWithImpl<T, $Res>
-    extends _$MutationStateCopyWithImpl<T, $Res, _$_Failure<T>>
-    implements _$$_FailureCopyWith<T, $Res> {
-  __$$_FailureCopyWithImpl(
-      _$_Failure<T> _value, $Res Function(_$_Failure<T>) _then)
-      : super(_value, _then);
-
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? error = null,
-    Object? stackTrace = null,
-  }) {
-    return _then(_$_Failure<T>(
-      null == error ? _value.error : error,
-      null == stackTrace
-          ? _value.stackTrace
-          : stackTrace // ignore: cast_nullable_to_non_nullable
-              as StackTrace,
-    ));
-  }
-}
-
-/// @nodoc
-
-class _$_Failure<T> extends _Failure<T> with DiagnosticableTreeMixin {
-  const _$_Failure(this.error, this.stackTrace) : super._();
-
-  @override
   final Object error;
-  @override
   final StackTrace stackTrace;
 
-  @override
-  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
-    return 'MutationState<$T>.failure(error: $error, stackTrace: $stackTrace)';
-  }
+  /// Create a copy of MutationState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$FailureCopyWith<T, _Failure<T>> get copyWith =>
+      __$FailureCopyWithImpl<T, _Failure<T>>(this, _$identity);
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
     properties
       ..add(DiagnosticsProperty('type', 'MutationState<$T>.failure'))
       ..add(DiagnosticsProperty('error', error))
@@ -539,10 +186,10 @@ class _$_Failure<T> extends _Failure<T> with DiagnosticableTreeMixin {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_Failure<T> &&
+            other is _Failure<T> &&
             const DeepCollectionEquality().equals(other.error, error) &&
             (identical(other.stackTrace, stackTrace) ||
                 other.stackTrace == stackTrace));
@@ -552,95 +199,44 @@ class _$_Failure<T> extends _Failure<T> with DiagnosticableTreeMixin {
   int get hashCode => Object.hash(
       runtimeType, const DeepCollectionEquality().hash(error), stackTrace);
 
-  @JsonKey(ignore: true)
   @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
+    return 'MutationState<$T>.failure(error: $error, stackTrace: $stackTrace)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$FailureCopyWith<T, $Res>
+    implements $MutationStateCopyWith<T, $Res> {
+  factory _$FailureCopyWith(
+          _Failure<T> value, $Res Function(_Failure<T>) _then) =
+      __$FailureCopyWithImpl;
+  @useResult
+  $Res call({Object error, StackTrace stackTrace});
+}
+
+/// @nodoc
+class __$FailureCopyWithImpl<T, $Res> implements _$FailureCopyWith<T, $Res> {
+  __$FailureCopyWithImpl(this._self, this._then);
+
+  final _Failure<T> _self;
+  final $Res Function(_Failure<T>) _then;
+
+  /// Create a copy of MutationState
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
-  _$$_FailureCopyWith<T, _$_Failure<T>> get copyWith =>
-      __$$_FailureCopyWithImpl<T, _$_Failure<T>>(this, _$identity);
-
-  @override
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>({
-    required TResult Function() idle,
-    required TResult Function() loading,
-    required TResult Function(T result) success,
-    required TResult Function(Object error, StackTrace stackTrace) failure,
+  $Res call({
+    Object? error = null,
+    Object? stackTrace = null,
   }) {
-    return failure(error, stackTrace);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function()? idle,
-    TResult? Function()? loading,
-    TResult? Function(T result)? success,
-    TResult? Function(Object error, StackTrace stackTrace)? failure,
-  }) {
-    return failure?.call(error, stackTrace);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>({
-    TResult Function()? idle,
-    TResult Function()? loading,
-    TResult Function(T result)? success,
-    TResult Function(Object error, StackTrace stackTrace)? failure,
-    required TResult orElse(),
-  }) {
-    if (failure != null) {
-      return failure(error, stackTrace);
-    }
-    return orElse();
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>({
-    required TResult Function(_Idle<T> value) idle,
-    required TResult Function(_Loading<T> value) loading,
-    required TResult Function(_Success<T> value) success,
-    required TResult Function(_Failure<T> value) failure,
-  }) {
-    return failure(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(_Idle<T> value)? idle,
-    TResult? Function(_Loading<T> value)? loading,
-    TResult? Function(_Success<T> value)? success,
-    TResult? Function(_Failure<T> value)? failure,
-  }) {
-    return failure?.call(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>({
-    TResult Function(_Idle<T> value)? idle,
-    TResult Function(_Loading<T> value)? loading,
-    TResult Function(_Success<T> value)? success,
-    TResult Function(_Failure<T> value)? failure,
-    required TResult orElse(),
-  }) {
-    if (failure != null) {
-      return failure(this);
-    }
-    return orElse();
+    return _then(_Failure<T>(
+      null == error ? _self.error : error,
+      null == stackTrace
+          ? _self.stackTrace
+          : stackTrace // ignore: cast_nullable_to_non_nullable
+              as StackTrace,
+    ));
   }
 }
 
-abstract class _Failure<T> extends MutationState<T> {
-  const factory _Failure(final Object error, final StackTrace stackTrace) =
-      _$_Failure<T>;
-  const _Failure._() : super._();
-
-  Object get error;
-  StackTrace get stackTrace;
-  @JsonKey(ignore: true)
-  _$$_FailureCopyWith<T, _$_Failure<T>> get copyWith =>
-      throw _privateConstructorUsedError;
-}
+// dart format on

--- a/lib/src/mutation_cubit.freezed.dart
+++ b/lib/src/mutation_cubit.freezed.dart
@@ -43,8 +43,8 @@ class $MutationStateCopyWith<T, $Res> {
 
 /// @nodoc
 
-class _Idle<T> extends MutationState<T> with DiagnosticableTreeMixin {
-  const _Idle() : super._();
+class Idle<T> extends MutationState<T> with DiagnosticableTreeMixin {
+  const Idle() : super._();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -54,7 +54,7 @@ class _Idle<T> extends MutationState<T> with DiagnosticableTreeMixin {
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
-        (other.runtimeType == runtimeType && other is _Idle<T>);
+        (other.runtimeType == runtimeType && other is Idle<T>);
   }
 
   @override
@@ -68,8 +68,8 @@ class _Idle<T> extends MutationState<T> with DiagnosticableTreeMixin {
 
 /// @nodoc
 
-class _Loading<T> extends MutationState<T> with DiagnosticableTreeMixin {
-  const _Loading() : super._();
+class Loading<T> extends MutationState<T> with DiagnosticableTreeMixin {
+  const Loading() : super._();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -79,7 +79,7 @@ class _Loading<T> extends MutationState<T> with DiagnosticableTreeMixin {
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
-        (other.runtimeType == runtimeType && other is _Loading<T>);
+        (other.runtimeType == runtimeType && other is Loading<T>);
   }
 
   @override
@@ -93,8 +93,8 @@ class _Loading<T> extends MutationState<T> with DiagnosticableTreeMixin {
 
 /// @nodoc
 
-class _Success<T> extends MutationState<T> with DiagnosticableTreeMixin {
-  const _Success(this.result) : super._();
+class Success<T> extends MutationState<T> with DiagnosticableTreeMixin {
+  const Success(this.result) : super._();
 
   final T result;
 
@@ -102,8 +102,8 @@ class _Success<T> extends MutationState<T> with DiagnosticableTreeMixin {
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
   @pragma('vm:prefer-inline')
-  _$SuccessCopyWith<T, _Success<T>> get copyWith =>
-      __$SuccessCopyWithImpl<T, _Success<T>>(this, _$identity);
+  $SuccessCopyWith<T, Success<T>> get copyWith =>
+      _$SuccessCopyWithImpl<T, Success<T>>(this, _$identity);
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -116,7 +116,7 @@ class _Success<T> extends MutationState<T> with DiagnosticableTreeMixin {
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _Success<T> &&
+            other is Success<T> &&
             const DeepCollectionEquality().equals(other.result, result));
   }
 
@@ -131,21 +131,20 @@ class _Success<T> extends MutationState<T> with DiagnosticableTreeMixin {
 }
 
 /// @nodoc
-abstract mixin class _$SuccessCopyWith<T, $Res>
+abstract mixin class $SuccessCopyWith<T, $Res>
     implements $MutationStateCopyWith<T, $Res> {
-  factory _$SuccessCopyWith(
-          _Success<T> value, $Res Function(_Success<T>) _then) =
-      __$SuccessCopyWithImpl;
+  factory $SuccessCopyWith(Success<T> value, $Res Function(Success<T>) _then) =
+      _$SuccessCopyWithImpl;
   @useResult
   $Res call({T result});
 }
 
 /// @nodoc
-class __$SuccessCopyWithImpl<T, $Res> implements _$SuccessCopyWith<T, $Res> {
-  __$SuccessCopyWithImpl(this._self, this._then);
+class _$SuccessCopyWithImpl<T, $Res> implements $SuccessCopyWith<T, $Res> {
+  _$SuccessCopyWithImpl(this._self, this._then);
 
-  final _Success<T> _self;
-  final $Res Function(_Success<T>) _then;
+  final Success<T> _self;
+  final $Res Function(Success<T>) _then;
 
   /// Create a copy of MutationState
   /// with the given fields replaced by the non-null parameter values.
@@ -153,7 +152,7 @@ class __$SuccessCopyWithImpl<T, $Res> implements _$SuccessCopyWith<T, $Res> {
   $Res call({
     Object? result = freezed,
   }) {
-    return _then(_Success<T>(
+    return _then(Success<T>(
       freezed == result
           ? _self.result
           : result // ignore: cast_nullable_to_non_nullable
@@ -164,8 +163,8 @@ class __$SuccessCopyWithImpl<T, $Res> implements _$SuccessCopyWith<T, $Res> {
 
 /// @nodoc
 
-class _Failure<T> extends MutationState<T> with DiagnosticableTreeMixin {
-  const _Failure(this.error, this.stackTrace) : super._();
+class Failure<T> extends MutationState<T> with DiagnosticableTreeMixin {
+  const Failure(this.error, this.stackTrace) : super._();
 
   final Object error;
   final StackTrace stackTrace;
@@ -174,8 +173,8 @@ class _Failure<T> extends MutationState<T> with DiagnosticableTreeMixin {
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
   @pragma('vm:prefer-inline')
-  _$FailureCopyWith<T, _Failure<T>> get copyWith =>
-      __$FailureCopyWithImpl<T, _Failure<T>>(this, _$identity);
+  $FailureCopyWith<T, Failure<T>> get copyWith =>
+      _$FailureCopyWithImpl<T, Failure<T>>(this, _$identity);
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -189,7 +188,7 @@ class _Failure<T> extends MutationState<T> with DiagnosticableTreeMixin {
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _Failure<T> &&
+            other is Failure<T> &&
             const DeepCollectionEquality().equals(other.error, error) &&
             (identical(other.stackTrace, stackTrace) ||
                 other.stackTrace == stackTrace));
@@ -206,21 +205,20 @@ class _Failure<T> extends MutationState<T> with DiagnosticableTreeMixin {
 }
 
 /// @nodoc
-abstract mixin class _$FailureCopyWith<T, $Res>
+abstract mixin class $FailureCopyWith<T, $Res>
     implements $MutationStateCopyWith<T, $Res> {
-  factory _$FailureCopyWith(
-          _Failure<T> value, $Res Function(_Failure<T>) _then) =
-      __$FailureCopyWithImpl;
+  factory $FailureCopyWith(Failure<T> value, $Res Function(Failure<T>) _then) =
+      _$FailureCopyWithImpl;
   @useResult
   $Res call({Object error, StackTrace stackTrace});
 }
 
 /// @nodoc
-class __$FailureCopyWithImpl<T, $Res> implements _$FailureCopyWith<T, $Res> {
-  __$FailureCopyWithImpl(this._self, this._then);
+class _$FailureCopyWithImpl<T, $Res> implements $FailureCopyWith<T, $Res> {
+  _$FailureCopyWithImpl(this._self, this._then);
 
-  final _Failure<T> _self;
-  final $Res Function(_Failure<T>) _then;
+  final Failure<T> _self;
+  final $Res Function(Failure<T>) _then;
 
   /// Create a copy of MutationState
   /// with the given fields replaced by the non-null parameter values.
@@ -229,7 +227,7 @@ class __$FailureCopyWithImpl<T, $Res> implements _$FailureCopyWith<T, $Res> {
     Object? error = null,
     Object? stackTrace = null,
   }) {
-    return _then(_Failure<T>(
+    return _then(Failure<T>(
       null == error ? _self.error : error,
       null == stackTrace
           ? _self.stackTrace

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.2.0
 repository: https://github.com/jarekb123/async_cubits
 
 environment:
-  sdk: ">=3.4.0 <4.0.0"
+  sdk: ">=3.6.0 <4.0.0"
   flutter: ">=3.29.0"
 
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,21 +4,21 @@ version: 0.2.0
 repository: https://github.com/jarekb123/async_cubits
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.10.0"
+  sdk: ">=3.4.0 <4.0.0"
+  flutter: ">=3.29.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  flutter_bloc: ^8.0.0
-  freezed_annotation: ^2.1.0
-  meta: ^1.8.0
+  flutter_bloc: ^9.1.0
+  freezed_annotation: ^3.0.0
+  meta: ^1.16.0
 
 dev_dependencies:
-  bloc_test: ^9.1.0
-  build_runner: ^2.4.6
+  bloc_test: ^10.0.0
+  build_runner: ^2.4.15
   flutter_test:
     sdk: flutter
-  freezed: ^2.3.4
-  mocktail: ^1.0.0
-  very_good_analysis: ^5.1.0
+  freezed: ^3.0.6
+  mocktail: ^1.0.4
+  very_good_analysis: ^7.0.0


### PR DESCRIPTION
- Changed MutationState from a regular class to a sealed class for better type safety.
- Refactored the implementation of MutationState subclasses (_Idle, _Loading, _Success, _Failure) to enhance readability and maintainability.
- Updated the equality and hashCode methods for better performance and correctness.
- Removed unnecessary boilerplate code generated by Freezed.
- Improved diagnostic properties for better debugging.

chore: Update pubspec.yaml dependencies

- Bumped Dart SDK version to >=3.4.0 <4.0.0 and Flutter version to >=3.29.0.
- Updated flutter_bloc to ^9.1.0, freezed_annotation to ^3.0.0, and meta to ^1.16.0.
- Updated dev dependencies: bloc_test to ^10.0.0, build_runner to ^2.4.15, freezed to ^3.0.6, mocktail to ^1.0.4, and very_good_analysis to ^7.0.0.